### PR TITLE
fix markdown syntax on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ app.listen(3000);
 console.log('Express started on port 3000');
 
 })();
-'''
+```
 
 ### Sample Output
 


### PR DESCRIPTION
This pull request fixes a broken syntax highlighting I found in the docs :)
